### PR TITLE
fix: update Bangumi calendar API endpoint

### DIFF
--- a/api/bgm_api.py
+++ b/api/bgm_api.py
@@ -21,7 +21,7 @@ class BGMAPI(BaseAPI):
             session: 可选的 aiohttp.ClientSession，如果提供则复用
         """
         super().__init__(session)
-        self.url = "https://api.bgm.tv/calendar"
+        self.url = "https://api.bangumi.one/calendar"
         self.headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
         }


### PR DESCRIPTION
## 变更说明



当前代码中 Bangumi 日历接口固定为：



```python

self.url = "https://api.bgm.tv/calendar"
```
在当前服务器环境下，原接口访问超时：
```
URL: https://api.bgm.tv/calendar
DNS: api.bgm.tv -> 103.228.130.61
ping: 4 packets transmitted, 0 received, 100% packet loss
curl: Failed to connect to api.bgm.tv port 443 after 5203 ms: Connection timed out
HTTP: 000
```
---

测试可用的新接口：
`https://api.bangumi.one/calendar`

更换后测试结果：
```
URL: https://api.bangumi.one/calendar
DNS: 可解析到 Cloudflare IP
ping: 4 packets transmitted, 4 received, 0% packet loss
HTTP: 200
content-type: application/json; charset=utf-8
size_download: 81547 bytes
time_total: 15.965729s
```
返回内容为正常的 Bangumi 日历 JSON，字段结构与现有解析逻辑兼容。
## 修改内容
将 BGM 日历接口从：
`self.url = "https://api.bgm.tv/calendar"`

更换为：
`self.url = "https://api.bangumi.one/calendar"`

测试结果
已运行：
`python3 -m py_compile api/bgm_api.py`

语法检查通过。